### PR TITLE
Require locale constants & PHP 8.x compatibility

### DIFF
--- a/l10n_update.admin.inc
+++ b/l10n_update.admin.inc
@@ -227,6 +227,8 @@ function l10n_update_status_form_submit($form, $form_state) {
  * Page callback: Settings form.
  */
 function l10n_update_admin_settings_form($form, &$form_state) {
+  require_once BACKDROP_ROOT . '/core/includes/locale.inc';
+
   $output = t('These are the settings for the translation update system. To update your translations now, check out the <a href="@update-admin">Translation update administration page</a>.', array('@update-admin' => url('admin/config/regional/translate/update')));
 
   $config = config('l10n_update.settings');

--- a/l10n_update.http.inc
+++ b/l10n_update.http.inc
@@ -234,7 +234,7 @@ function l10n_update_http_request($url, array $options = array()) {
   // or PUT request. Some non-standard servers get confused by Content-Length in
   // at least HEAD/GET requests, and Squid always requires Content-Length in
   // POST/PUT requests.
-  $content_length = strlen($options['data']);
+  $content_length = strlen($options['data'] ?? '');
   if ($content_length > 0 || $options['method'] == 'POST' || $options['method'] == 'PUT') {
     $options['headers']['Content-Length'] = $content_length;
   }
@@ -309,7 +309,7 @@ function l10n_update_http_request($url, array $options = array()) {
   $result->headers = array();
 
   // Parse the response headers.
-  while ($line = trim(array_shift($response))) {
+  while ($line = trim(array_shift($response) ?? '')) {
     list($name, $value) = explode(':', $line, 2);
     $name = strtolower($name);
     if (isset($result->headers[$name]) && $name == 'set-cookie') {

--- a/l10n_update.http.inc
+++ b/l10n_update.http.inc
@@ -309,7 +309,7 @@ function l10n_update_http_request($url, array $options = array()) {
   $result->headers = array();
 
   // Parse the response headers.
-  while ($line = trim(array_shift($response) ?? '')) {
+  while ($line = trim(!empty(array_shift($response)) ? array_shift($response) : '')) {
     list($name, $value) = explode(':', $line, 2);
     $name = strtolower($name);
     if (isset($result->headers[$name]) && $name == 'set-cookie') {

--- a/l10n_update.http.inc
+++ b/l10n_update.http.inc
@@ -234,7 +234,7 @@ function l10n_update_http_request($url, array $options = array()) {
   // or PUT request. Some non-standard servers get confused by Content-Length in
   // at least HEAD/GET requests, and Squid always requires Content-Length in
   // POST/PUT requests.
-  $content_length = strlen($options['data'] ?? '');
+  $content_length = strlen(isset($options['data']) ? $options['data'] : '');
   if ($content_length > 0 || $options['method'] == 'POST' || $options['method'] == 'PUT') {
     $options['headers']['Content-Length'] = $content_length;
   }

--- a/l10n_update.translation.inc
+++ b/l10n_update.translation.inc
@@ -312,7 +312,7 @@ function l10n_update_build_server_pattern($project, $template) {
     '%core' => $project->core,
     '%language' => isset($project->langcode) ? $project->langcode : '%language',
   );
-  return strtr($template, $variables);
+  return strtr($template ?? '', $variables);
 }
 
 /**
@@ -424,6 +424,8 @@ function _l10n_update_source_compare($source1, $source2) {
  *   Array of translation import options.
  */
 function _l10n_update_default_update_options() {
+  require_once BACKDROP_ROOT . '/core/includes/locale.inc';
+
   $options = array(
     'customized' => L10N_UPDATE_NOT_CUSTOMIZED,
     'finish_feedback' => TRUE,

--- a/l10n_update.translation.inc
+++ b/l10n_update.translation.inc
@@ -312,7 +312,7 @@ function l10n_update_build_server_pattern($project, $template) {
     '%core' => $project->core,
     '%language' => isset($project->langcode) ? $project->langcode : '%language',
   );
-  return strtr($template ?? '', $variables);
+  return strtr($template ? $template : '', $variables);
 }
 
 /**


### PR DESCRIPTION
Require locale constants.
PHP 8.x compatibility.