### PR TITLE
fix typo to avoid warning about 'complete form' missing index

### DIFF
--- a/l10n_update.module
+++ b/l10n_update.module
@@ -431,8 +431,7 @@ function l10n_update_locale_translate_edit_form_submit($form, &$form_state) {
   $languages = $form_state['values']['translations'];
   $languages = array_intersect_key($languages, l10n_update_translatable_language_list());
   foreach ($languages as $langcode => $value) {
-    // ERROR: Notice: Undefined index: complete form
-    if (!empty($value) && $value != $form_state['complete form']['translations'][$langcode]['#default_value']) {
+    if (!empty($value) && $value != $form_state['complete_form']['translations'][$langcode]['#default_value']) {
       // An update has been made, mark the string as customized.
       db_update('locales_target')
         ->fields(array('l10n_status' => L10N_UPDATE_STRING_CUSTOM))


### PR DESCRIPTION
it seems there is a typo - "complete form" should be "complete_form"